### PR TITLE
Rework and Format

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,11 @@
 // Copyright 2019 Thomas Nicollet
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,7 +15,6 @@
 extern crate protobuf_codegen_pure;
 
 fn main() {
-
     protobuf_codegen_pure::run(protobuf_codegen_pure::Args {
         out_dir: "src/protos",
         input: &["protos/component_schema.proto", "protos/entity.proto"],
@@ -24,5 +23,6 @@ fn main() {
             serde_derive: Some(true),
             ..Default::default()
         },
-    }).expect("protoc");
+    })
+    .expect("protoc");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,61 +1,66 @@
 // Copyright 2019 Thomas Nicollet
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use byteorder::{ReadBytesExt, WriteBytesExt, BigEndian, LittleEndian};
-
-#[macro_use]
-extern crate serde;
-use std::collections::HashMap;
-use std::sync::{Mutex, Arc};
-use std::fs;
-use std::path::PathBuf;
 mod protos;
-use std::net::{TcpListener, TcpStream, Shutdown};
-use std::thread;
-use std::io::{Read};
-use protobuf::{parse_from_bytes};
-use protobuf::Message;
 
-const FILENAME: &'static str = "schema.json";
+use byteorder::{BigEndian, WriteBytesExt};
+
+extern crate serde;
+use protobuf::parse_from_bytes;
+use protobuf::Message;
+use protos::{
+    component_schema::AddComponentSchema,
+    entity::{Component, ComponentValue, CreateEntity},
+};
+use std::collections::HashMap;
+use std::io::Read;
+use std::net::{Shutdown, TcpStream};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+const FILENAME: &str = "schema.json";
 
 mod entity;
 mod schema;
 
-use schema::{Schema, AttributeType};
+use schema::{AttributeType, Schema};
 
 fn handle_client(mut stream: TcpStream, schema: Arc<Mutex<Schema>>) {
     let mut data = [0 as u8; 1024]; // using 50 byte buffer
+
     while match stream.read(&mut data) {
+        Ok(0) => false,
         Ok(size) => {
-            match size {
-                0 => false,
-                _ => {
-                    match parse_from_bytes::<protos::component_schema::AddComponentSchema>(&data[0..size]) {
-                        Ok(parsed) => {
-                            let proto_schema = parsed.schema.unwrap();
-                            let name = String::from(&proto_schema.name);
-                            schema.lock().unwrap().add_component(&name, HashMap::from(proto_schema));
-                            schema.lock().unwrap().write_schema(PathBuf::from(FILENAME));
-                        },
-                        Err(_) => ()
-                    }
-                    true
+            if let Ok(parsed) = parse_from_bytes::<AddComponentSchema>(&data[0..size]) {
+                let proto_schema = parsed.schema.unwrap();
+                let name = String::from(&proto_schema.name);
+                schema
+                    .lock()
+                    .unwrap()
+                    .add_component(&name, HashMap::from(proto_schema));
+                if let Err(err) = schema.lock().unwrap().write_schema(PathBuf::from(FILENAME)) {
+                    eprintln!("An error occured {}", err);
                 }
             }
-        },
-        Err(_) => {
-            println!("An error occurred, terminating connection with {}", stream.peer_addr().unwrap());
+            true
+        }
+        Err(err) => {
+            eprintln!(
+                "An error occurred, terminating connection with {}, {}",
+                stream.peer_addr().unwrap(),
+                err
+            );
             stream.shutdown(Shutdown::Both).unwrap();
             false
         }
@@ -64,15 +69,15 @@ fn handle_client(mut stream: TcpStream, schema: Arc<Mutex<Schema>>) {
 
 fn main() {
     let schema = Arc::new(Mutex::new(Schema::from(PathBuf::from(FILENAME))));
-    let mut ent = protos::entity::CreateEntity::default();
-    let mut comp = protos::entity::Component::default();
-    let mut x = protos::entity::ComponentValue::default();
+    let mut ent = CreateEntity::default();
+    let mut comp = Component::default();
+    let mut x = ComponentValue::default();
     x.name = String::from("x");
     x.value.write_u64::<BigEndian>(517).unwrap();
-    let mut y = protos::entity::ComponentValue::default();
+    let mut y = ComponentValue::default();
     y.name = String::from("y");
     y.value.write_u64::<BigEndian>(12).unwrap();
-    let mut z = protos::entity::ComponentValue::default();
+    let mut z = ComponentValue::default();
     z.name = String::from("z");
     z.value.write_u64::<BigEndian>(25).unwrap();
     comp.name = String::from("Velocity");
@@ -103,10 +108,7 @@ fn main() {
 
     drop(listener);
     */
-    match schema.lock().unwrap().write_schema(PathBuf::from(FILENAME)) {
-        Ok(_) => (),
-        Err(err) => {
-            println!("Error: {:?}", err);
-        }
+    if let Err(err) = schema.lock().unwrap().write_schema(PathBuf::from(FILENAME)) {
+        eprintln!("Error: {:?}", err);
     };
 }

--- a/src/protos/mod.rs
+++ b/src/protos/mod.rs
@@ -1,11 +1,11 @@
 // Copyright 2019 Thomas Nicollet
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -14,9 +14,10 @@
 
 use super::protos;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
-use std::collections::HashMap;
+use std::hash::BuildHasher;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum AttributeType {
@@ -31,7 +32,6 @@ pub struct Schema {
 }
 
 impl From<protos::component_schema::AttributeType> for AttributeType {
-
     fn from(attribute_type: protos::component_schema::AttributeType) -> Self {
         match attribute_type {
             protos::component_schema::AttributeType::Integer => Self::Integer,
@@ -39,7 +39,6 @@ impl From<protos::component_schema::AttributeType> for AttributeType {
             protos::component_schema::AttributeType::Float => Self::Float,
         }
     }
-
 }
 
 impl From<protos::component_schema::ComponentSchema> for HashMap<String, AttributeType> {


### PR DESCRIPTION
# Formatting

Using `cargo fmt` to format code to rust coding style.

# Idiomatic rework

Replace some `match` with idiomatic function like [`ok_or`](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or) and `if let Err(err) {}` statement.

# Not tested :warning: 

> The code is not tested.

